### PR TITLE
fix typo in wmGenFolds

### DIFF
--- a/wmGenFolds
+++ b/wmGenFolds
@@ -104,7 +104,7 @@ experiments.eachWithIndex{exp,idx->
 			instancesMinusHoldout = WekaMine.removeInstances(instances,holdoutIDs)
 			err.println "\t${holdoutIDs.size()} holdout samples set aside. ${instancesMinusHoldout.numInstances()} instances remaining for cross-validaion."
 		}else{
-			instancesMinusHouldout = instances
+			instancesMinusHoldout = instances
 		}
 		
 		// Determine if there are enough examples of each class left for the number of folds requested. 


### PR DESCRIPTION
fix typo in wmGenFolds

pls ignore the first reverted change - I did not have username configured

Thanks,
Adrian.
